### PR TITLE
Started .bazelrc for C++ 17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build:macos --cxxopt='-std=c++17'


### PR DESCRIPTION
Creates .bazelrc to compile with C++17.